### PR TITLE
chore: Improve VM property checking

### DIFF
--- a/src/firewheel_repo_vyos/equuleus/model_component_objects.py
+++ b/src/firewheel_repo_vyos/equuleus/model_component_objects.py
@@ -112,22 +112,22 @@ class Equuleus:
 
         self.vm = getattr(self, "vm", {})
 
-        if "architecture" not in self.vm:
+        if not self.vm.get("architecture"):
             self.vm["architecture"] = "x86_64"
-        if "vcpu" not in self.vm:
+        if not self.vm.get("vcpu"):
             self.vm["vcpu"] = {
                 "model": "qemu64",
                 "sockets": 1,
                 "cores": 1,
                 "threads": 1,
             }
-        if "mem" not in self.vm:
+        if not self.vm.get("mem"):
             self.vm["mem"] = 256
-        if "drives" not in self.vm:
+        if not self.vm.get("drives"):
             self.vm["drives"] = [
                 {"db_path": "vyos-equuleus.qc2.xz", "file": "vyos-equuleus.qc2"}
             ]
-        if "vga" not in self.vm:
+        if not self.vm.get("vga"):
             self.vm["vga"] = "std"
 
         self.set_image("vyos-equuleus")

--- a/src/firewheel_repo_vyos/vyos-1.1.8/model_component_objects.py
+++ b/src/firewheel_repo_vyos/vyos-1.1.8/model_component_objects.py
@@ -105,22 +105,22 @@ class Helium118:
 
         self.vm = getattr(self, "vm", {})
 
-        if "architecture" not in self.vm:
+        if not self.vm.get("architecture"):
             self.vm["architecture"] = "x86_64"
-        if "vcpu" not in self.vm:
+        if not self.vm.get("vcpu"):
             self.vm["vcpu"] = {
                 "model": "qemu64",
                 "sockets": 1,
                 "cores": 1,
                 "threads": 1,
             }
-        if "mem" not in self.vm:
+        if not self.vm.get("mem"):
             self.vm["mem"] = 256
-        if "drives" not in self.vm:
+        if not self.vm.get("drives"):
             self.vm["drives"] = [
                 {"db_path": "vyos-1.1.8.qc2.xz", "file": "vyos-1.1.8.qc2"}
             ]
-        if "vga" not in self.vm:
+        if not self.vm.get("vga"):
             self.vm["vga"] = "std"
 
         self.set_image("vyos-1.1.8")


### PR DESCRIPTION
Improve VM property checking for falsy values rather than just missing keys in the Vertex vm dictionary. This is the "proper" way to check a dictionary and will also provide more robust checks.